### PR TITLE
aug 19 megamix 4: safe frontend (next quick-reply design iteration)

### DIFF
--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -23,14 +23,15 @@ function update(data,widget) {
         data.dtid = data.target;
     } else {
         data.dtid = 0;
+        data.journalDomain = targetParts[1].replace("_", "-") + "." + Site.user_domain;
         $("#journal").val(targetParts[1]);
         $("#itemid").val(targetParts[2]);
-        $("#basepath").val(document.location.protocol + "//" +
-                            targetParts[1].replace("_", "-") + "." + Site.user_domain +
+        $("#basepath").val(document.location.protocol + "//" + data.journalDomain +
                             "/" + targetParts[2] + ".html?");
         data.stayOnPage = true;
     }
     $("#qrform").data("stayOnPage", data.stayOnPage);
+    $("#qrform").data("journalDomain", data.journalDomain);
 
     $("#parenttalkid, #replyto").val(data.pid);
     $("#dtid").val(data.dtid);
@@ -108,6 +109,7 @@ $.widget("dw.quickreply", {
     options: {
         target: undefined,
         stayOnPage: false,
+        journalDomain: undefined,
         dtid: undefined,
         pid: undefined,
         subject: undefined
@@ -242,7 +244,21 @@ jQuery(function($) {
         }
 
         qrform.data("stayOnPage", false);
-        qrform.submit();
+
+        var journalDomain = qrform.data("journalDomain");
+
+        if ( fetch && journalDomain && journalDomain !== document.location.hostname ) {
+            // Make a bogus request to the other journal to ensure our cookies
+            // are in order before we submit. This protects your comment text
+            // when replying from the reading page.
+            fetch(document.location.protocol + '//' + journalDomain + '/robots.txt',
+                {mode: 'no-cors', credentials: 'include'}
+            ).then(function(response) {
+                qrform.submit();
+            });
+        } else {
+            qrform.submit();
+        }
     });
 
 });

--- a/htdocs/js/jquery.quickreply.js
+++ b/htdocs/js/jquery.quickreply.js
@@ -49,6 +49,8 @@ function update(data,widget) {
     if ( ! customsubject || cur_subject == "" )
         subject.val(data.subject);
 
+    $("#prop_picture_keyword").change();
+
     // If we previously munged the layout of #qrformdiv, reset it.
     $('#qrformdiv').removeAttr('style').removeClass('width-adjusted');
 
@@ -225,18 +227,24 @@ jQuery(function($) {
         $("#qrform").attr("action", Site.siteroot + "/talkpost_do" );
     });
     $("#submitmoreopts").on("click", function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var qrform = $("#qrform");
         var replyto = Number($("#dtid").val());
         var pid = Number($("#parenttalkid").val());
         var basepath = $("#basepath").val();
 
         if(replyto > 0 && pid > 0) {
-            $("#qrform").attr("action", basepath + "replyto=" + replyto );
+            qrform.attr("action", basepath + "replyto=" + replyto );
         } else {
-            $("#qrform").attr("action", basepath + "mode=reply" );
+            qrform.attr("action", basepath + "mode=reply" );
         }
 
-        $("#qrform").data("stayOnPage", false);
+        qrform.data("stayOnPage", false);
+        qrform.submit();
     });
+
 });
 
 

--- a/htdocs/js/jquery.replyforms.js
+++ b/htdocs/js/jquery.replyforms.js
@@ -18,29 +18,47 @@ jQuery(function($) {
     $(".js-only").show();
     $(".no-js").hide();
 
-    // Random icon button
-    $("#randomicon").on("click", function(e){
-        e.stopPropagation();
-        e.preventDefault();
-
+    function randomIcon() {
         if ( iconSelect.length === 0 ) return;
 
-        // take a random number, ignoring the "(default)" option
+        // take a random number, ignoring the "(default)" and "(random)" options
         var randomnumber = Math.floor(
-            Math.random() * (iconSelect.prop("length") - 1)
-        ) + 1;
+            Math.random() * (iconSelect.prop("length") - 2)
+        ) + 2;
         iconSelect.prop("selectedIndex", randomnumber);
-        iconSelect.trigger("change");
-    });
+        iconSelect.change();
+    }
 
-    // Icon preview
+    // Add random icon option to menu if there's more than one icon
+    if ( $('option#random').length === 0 && iconSelect.children('option').length > 2 ) {
+        iconSelect.children('option').first()
+            .after('<option value=",random" id="random">(random) 🔀</option>');
+            // Commas are illegal in keywords, so this won't conflict with
+            // anyone's real icons. Since the value immediately changes to
+            // something else if you select it, this should never be
+            // submitted... but if it is, it just reverts to the default icon.
+    }
+
+    // Random icon re-roll button (hidden until random is selected once)
+    $("#randomicon").on("click", randomIcon);
+
     iconSelect.on("change", function(e) {
-        e.stopPropagation();
-        e.preventDefault();
-
-        $(".qr-icon").find("img")
-            .attr("src", $(this).find("option:selected").data("url"))
-            .removeAttr("width").removeAttr("height").removeAttr("alt");
+        var selection = $(this).find("option:selected");
+        if (selection.attr('id') === 'random') {
+            randomIcon();
+            // For easy re-rolls:
+            $("#randomicon").show();
+        } else {
+            // Update icon preview
+            $(".qr-icon").find("img")
+                .attr("src", selection.data("url"))
+                .removeAttr("width").removeAttr("height").removeAttr("alt");
+            if (selection.attr('value') === '') {
+                $(".qr-icon").addClass("default");
+            } else {
+                $(".qr-icon").removeClass("default");
+            }
+        }
     });
 
     // Quote button

--- a/htdocs/scss/components/quick-reply.scss
+++ b/htdocs/scss/components/quick-reply.scss
@@ -1,12 +1,10 @@
 @import "foundation/base";
 
-$icon-control-height: 2.2em;
-
 #qrdiv * {
     box-sizing: border-box;
 }
 
-#qrform {
+#qrformdiv {
     text-align: left;
     padding: .5em;
     clear: both;
@@ -24,6 +22,12 @@ $icon-control-height: 2.2em;
 
     input, button, textarea, select {
         margin-bottom: 3px;
+        margin-top: 0;
+    }
+
+    input[type="button"], button {
+        // Avoids double-tap zoom when tapping "random" repeatedly
+        touch-action: manipulation;
     }
 
     // Avoid *dramatic woodchuck* zoom on mobile
@@ -33,90 +37,155 @@ $icon-control-height: 2.2em;
         }
     }
 
+    // If no grid: vertical stack. ID -> icon preview -> icon controls.
     .qr-meta {
-        display: flex;
-        align-items: flex-end;
+
+        display: grid;
+        grid-column-gap: 5px;
+        grid-template-columns: auto 1fr;
+        grid-template-rows: auto auto auto;
+        grid-template-areas:
+            "name name"
+            "icon more"
+            "icon iconctl";
+        .qr-icon {
+            margin-bottom: 3px;
+            grid-area: icon;
+            align-self: self-end;
+        }
+        .qr-icon-controls {
+            grid-area: iconctl;
+        }
+        .ljuser {
+            grid-area: name;
+            margin-bottom: 2px;
+            font-size: smaller;
+        }
+        #submitmoreopts {
+            grid-area: more;
+            justify-self: start;
+            align-self: self-end;
+            font-size: smaller;
+        }
     }
 
     .qr-icon {
-        // Same height as stacked icon controls
         width: 55px;
         height: 55px;
-        flex-shrink: 0;
-        margin-right: 3px;
-        margin-bottom: 3px;
 
         img {
             max-width: 100%;
             max-height: 100%;
+
+            @supports (object-position: bottom) {
+                width: 100%;
+                height: 100%;
+                object-fit: contain;
+                object-position: bottom;
+            }
+        }
+
+        a, button {
+            position: relative;
+            display: block;
+
+            width: 100%;
+            height: 100%;
+            border: none;
+            padding: 0;
+            margin: 0;
+            background: none;
+            cursor: pointer;
+
+            &::after {
+                position: absolute;
+
+                display: block; // old browsers
+                display: flex;  // new browsers
+                align-items: flex-end;
+                justify-content: center;
+
+                top: 0;
+                margin: 0;
+                font-size: 11px;
+                font-weight: bold;
+                opacity: 0;
+                background: rgba(255, 255, 255, 0.7); // real old browsers
+                background: radial-gradient(
+                    circle farthest-side at left 50% bottom -60%,
+                    rgba(255, 255, 255, 1.0),
+                    rgba(255, 255, 255, 0.85) 50%,
+                    rgba(255, 255, 255, 0) 67%
+                );
+                color: rgba(0, 0, 0, 0.8);
+                text-shadow: 0px -1px 3px #fff;
+                text-align: center;
+                width: 100%;
+                height: 100%;
+                @include single_transition();
+            }
+
+            &:hover, &:focus {
+                &::after {
+                    opacity: 1;
+                }
+            }
+        }
+
+        a::after {
+            content: "View all";
+        }
+
+        button::after {
+            content: "Browse";
+        }
+
+        &.default {
+            a, button {
+                &::after {
+                    opacity: 1;
+                }
+            }
         }
     }
 
     .qr-icon-controls {
-        & > * {
-            margin-bottom: 3px;
+        display: flex;
+        align-items: flex-end;
+        min-width: 0; // let grid shrink it
+
+        #randomicon {
+            margin-left: 5px;
         }
 
         select#prop_picture_keyword {
-            display: block;
-            @supports (display: flex) {
-                width: 100%;
-            }
+            margin-left: 0;
+            max-width: 100%;
+            min-width: 0; // Let grid/flex shrink it
         }
     }
 
-    button.lj_userpicselect_extra {
-        position: relative;
-        width: 100%;
-        height: 100%;
-        border: none;
-        padding: 0;
-        margin: 0;
-        background: none;
-        cursor: pointer;
-
-        &::after {
-            content: "Browse";
-            display: block;
-            position: absolute;
-            top: 0;
-            margin: 0 auto;
-            font-weight: bold;
-            line-height: 60px;
-            color: #000;
-            background-color: #fff;
-            text-align: center;
-            width: 100%;
-            height: 100%;
-            opacity: 0;
-            @include single_transition();
-        }
-
-        &:hover, &:focus {
-            &::after {
-                opacity: .7;
-            }
-        }
-    }
-
-    .qr-body {
+    .qr-subject {
         display: flex;
-        flex-wrap: wrap;
         align-items: flex-end;
 
         #subject {
             // size=50 in html is a presentational hint for width, so need to
             // set width to SOMETHING to keep it from messing up the flex.
             width: 70%;
+            min-width: 0; // let it shrink
             flex-grow: 1;
             flex-shrink: 1;
         }
         #comment-text-quote {
             margin-left: 5px;
         }
+    }
+
+    .qr-body {
         #body {
             width: 100%;
-            flex-shrink: 0;
+            -webkit-overflow-scrolling: touch;
         }
     }
 
@@ -136,16 +205,12 @@ $icon-control-height: 2.2em;
         }
     }
 
-    #submitmoreopts {
-        margin-left: 0;
-    }
-
     textarea, select, input[type="text"] {
-        margin-right: 0; // Fix for site scheme.
+        margin-right: 0; // Fix for old site scheme.
     }
 
     .invisible {
-        // Fix for site scheme; a ".comment .invisible" rule was setting position: relative.
+        // Fix for old site scheme; a ".comment .invisible" rule was setting position: relative.
         position: absolute;
     }
 }

--- a/views/journal/quickreply.tt
+++ b/views/journal/quickreply.tt
@@ -18,9 +18,15 @@ the same terms as Perl itself.  For a copy of the license, please reference
 [%- hidden_form_elements -%]
 
 <div class='qr-meta'>
+  [%- remote.ljuser %]
+
+  <a href="#" id="submitmoreopts" name="submitmoreopts">[% '/talkread.bml.button.more' | ml %]</a>
+
   <div class='qr-icon'>
     [%- IF remote.can_use_userpic_select -%]
-      <button type='button' class='lj_userpicselect_extra'>
+      <button type='button' id='lj_userpicselect' data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]">
+    [%- ELSE -%]
+      <a href="[% remote.icons_url %]">
     [%- END -%]
     [%- IF current_icon -%]
       [%- current_icon.imgtag -%]
@@ -29,17 +35,13 @@ the same terms as Perl itself.  For a copy of the license, please reference
     [%- END -%]
     [%- IF remote.can_use_userpic_select -%]
       </button>
+    [%- ELSE -%]
+      </a>
     [%- END -%]
   </div>
 
   [%- IF remote.icons.size > 0 -%]
     <div class='qr-icon-controls'>
-      [%- IF remote.can_use_userpic_select -%]
-        <input type="button" value="Browse" id="lj_userpicselect" data-iconbrowser-metatext="[%- remote.iconbrowser_metatext -%]" data-iconbrowser-smallicons="[%- remote.iconbrowser_smallicons -%]" />
-      [%- END %]
-
-      <input type='button' id='randomicon' value='Random' />
-
       <label for='prop_picture_keyword' class='invisible'>[%- '/talkpost.bml.label.picturetouse2' | ml( aopts = "href='$remote.icons_url'" ) -%]</label>
       [%- form.select(
           name = 'prop_picture_keyword',
@@ -47,11 +49,14 @@ the same terms as Perl itself.  For a copy of the license, please reference
           selected = current_icon_kw,
           items = remote.icons
       ) -%]
+
+      <input type="button" id="randomicon" value="Random" style="display: none;" />
     </div>
   [%- END -%]
+
 </div>
 
-<div class="qr-body">
+<div class="qr-subject">
   [%- form.textbox(
         label = dw.ml( '/talkpost.bml.opt.subject2' )
         labelclass = 'invisible'
@@ -63,7 +68,9 @@ the same terms as Perl itself.  For a copy of the license, please reference
   ) -%]
 
   <input type="button" id="comment-text-quote" value="Quote" tabindex="-1" class="js-only markup-button" data-quote-error="[%- 'talk.error.quickquote' | ml -%]" />
+</div>
 
+<div class="qr-body">
   [%- form.textarea(
     label = dw.ml( '/talkpost.bml.opt.message2' )
     labelclass = 'invisible'
@@ -93,12 +100,6 @@ the same terms as Perl itself.  For a copy of the license, please reference
       id = 'submitpview'
   ) -%]
   [%- form.hidden( name = 'submitpreview', value = 0 ) %]
-
-  [% form.submit(
-      name = 'submitmoreopts'
-      value = dw.ml( '/talkread.bml.button.more' ),
-      id = 'submitmoreopts'
-  ) %]
 
   [% help.icon %]
   [%- IF journal.is_iplogging %]


### PR DESCRIPTION
This is a subset of #2574.
Fixes #2521
Fixes #2522

These commits are:

- Front-end only. 
- Relatively low-risk. 
    - I guess we've all learned that QR design changes aren't _THAT_ low-risk, but this iteration has been extensively discussed in Discord, GH issues, and an ad-hoc alpha organized on dw-dev.

Aside from the question of CSS correctness, THIS is the commit that could really use functional and aesthetic review from a site owner, because it messes with a high-profile feature and it does so "live" (not behind a beta). Again, we've talked all these changes through before, but let's dot/cross the final eyes/tees.

- The commit message has all the details.
- I made sure you can resize the textarea! 😭
- Reminder to Nick: Might wanna amend the commit message to remove "classes for foundation," since I decided to move that issue into the skins themselves instead of polluting the markup here. 